### PR TITLE
Adding rssi value to the noke device

### DIFF
--- a/nokemobilelibrary/src/main/java/com/noke/nokemobilelibrary/NokeDeviceManagerService.java
+++ b/nokemobilelibrary/src/main/java/com/noke/nokemobilelibrary/NokeDeviceManagerService.java
@@ -602,7 +602,7 @@ public class NokeDeviceManagerService extends Service {
                                 }else if(addlockState == 0){
                                     lockState = NokeDefines.NOKE_LOCK_STATE_UNLOCKED;
                                 }else{
-                                    lockState = NokeDefines.NOKE_LOCK_STATE_UNKNOWN;;
+                                    lockState = NokeDefines.NOKE_LOCK_STATE_UNKNOWN;
                                 }
                             }
 
@@ -613,6 +613,7 @@ public class NokeDeviceManagerService extends Service {
                                 nokeDevices.put(noke.getMac(), noke);
                             }
                             noke.lockState = lockState;
+                            noke.rssi = rssi;
                             mGlobalNokeListener.onNokeDiscovered(noke);
                         }
                     }


### PR DESCRIPTION
Adding rssi value to the noke device as spected in the NokeServiceListener implementation.
The value is in the callback method but its never assigned to the noke object, I debugged the library and the value was valid so we can just assign it to the device, maybe someone forgot to add it. If there is any reason why thats that way or there is another way to get this value, please let me know.