### PR TITLE
Adding get and set for the RSSI value on the NokeDevice object

### DIFF
--- a/nokemobilelibrary/src/main/java/com/noke/nokemobilelibrary/NokeDevice.java
+++ b/nokemobilelibrary/src/main/java/com/noke/nokemobilelibrary/NokeDevice.java
@@ -276,6 +276,10 @@ public class NokeDevice {
         this.connectionState = connectionState;
     }
 
+    public int getRssi() { return rssi; }
+
+    public void setRssi(int rssi) { this.rssi = rssi; }
+
     /**
      * Sends a + delimited string of commands to the lock
      *


### PR DESCRIPTION
Adding get and set for the RSSI value on the NokeDevice object, the value is set on the device but there is no way to access it without this change 