### PR TITLE
Add support for setting mobile API keys dynamically

### DIFF
--- a/nokemobilelibrary/src/main/java/com/noke/nokemobilelibrary/NokeDeviceManagerService.java
+++ b/nokemobilelibrary/src/main/java/com/noke/nokemobilelibrary/NokeDeviceManagerService.java
@@ -188,6 +188,24 @@ public class NokeDeviceManagerService extends Service {
 
             return NokeDeviceManagerService.this;
         }
+
+        /**
+         * Returns reference to the NokeDeviceManagerService
+         *
+         * @param mode must be set upon initialization. Determines the upload url used for uploading
+         *             responses from the lock to the Core API.  Mode types can be found in NokeDefines
+         *             file:
+         *             - Sandbox (NOKE_LIBRARY_SANDBOX)
+         *             - Production (NOKE_LIBRARY_PRODUCTION)
+         *             - Develop (NOKE_LIBRARY_DEVELOP)
+         * @param mobileApiKey Mobile API key. If not set here it must instead be specified in
+         *                     the Android manifest.
+         */
+        public NokeDeviceManagerService getService(int mode, String mobileApiKey) {
+            NokeDeviceManagerService service = getService(mode);
+            service.setMobileApiKey(mobileApiKey);
+            return service;
+        }
     }
 
     /**
@@ -198,6 +216,31 @@ public class NokeDeviceManagerService extends Service {
     @Override
     public IBinder onBind(Intent intent) {
         return mBinder;
+    }
+
+    private String mMobileApiKey;
+
+    private String getMobileApiKey() {
+        if (mMobileApiKey != null) {
+            return mMobileApiKey;
+        }
+
+        try {
+            PackageManager pm = getApplicationContext().getPackageManager();
+            ApplicationInfo ai = pm.getApplicationInfo(getApplicationContext().getPackageName(), PackageManager.GET_META_DATA);
+            Bundle bundle = ai.metaData;
+            return bundle.getString(NokeDefines.NOKE_MOBILE_API_KEY);
+        } catch (PackageManager.NameNotFoundException | NullPointerException e) {
+            e.printStackTrace();
+            String message = "No API Key found. Have you set it in your Android Manifest or through setMobileApiKey()?";
+            mGlobalNokeListener.onError(null, NokeMobileError.ERROR_MISSING_API_KEY, message);
+
+            throw new IllegalStateException(message, e);
+        }
+    }
+
+    private void setMobileApiKey(String mobileApiKey) {
+        mMobileApiKey = mobileApiKey;
     }
 
     @Override
@@ -1141,16 +1184,8 @@ public class NokeDeviceManagerService extends Service {
                         data.put(globalUploadQueue.get(i));
                     }
                     jsonObject.accumulate("logs", data);
-                    try {
-                        PackageManager pm = getApplicationContext().getPackageManager();
-                        ApplicationInfo ai = pm.getApplicationInfo(getApplicationContext().getPackageName(), PackageManager.GET_META_DATA);
-                        Bundle bundle = ai.metaData;
-                        String nokeMobileApiKey = bundle.getString(NokeDefines.NOKE_MOBILE_API_KEY);
-                        this.uploadDataCallback(NokeMobileApiClient.POST(NokeDefines.uploadURL, jsonObject.toString(), nokeMobileApiKey, proxyAddress, port));
-                    } catch (PackageManager.NameNotFoundException | NullPointerException e) {
-                        e.printStackTrace();
-                        mGlobalNokeListener.onError(null, NokeMobileError.ERROR_MISSING_API_KEY, "No API Key found. Have you set it in your Android Manifest?");
-                    }
+                    String nokeMobileApiKey = getMobileApiKey();
+                    this.uploadDataCallback(NokeMobileApiClient.POST(NokeDefines.uploadURL, jsonObject.toString(), nokeMobileApiKey, proxyAddress, port));
                 } catch (Exception e) {
                     e.printStackTrace();
                 }
@@ -1480,17 +1515,8 @@ public class NokeDeviceManagerService extends Service {
                     jsonObject.accumulate("session", noke.getSession());
                     jsonObject.accumulate("mac", noke.getMac());
                     String url = NokeDefines.uploadURL.replace("upload/", "restore/");
-                    try {
-                        PackageManager pm = getApplicationContext().getPackageManager();
-                        ApplicationInfo ai = pm.getApplicationInfo(getApplicationContext().getPackageName(), PackageManager.GET_META_DATA);
-                        Bundle bundle = ai.metaData;
-                        String nokeMobileApiKey = bundle.getString(NokeDefines.NOKE_MOBILE_API_KEY);
-                        NokeDeviceManagerService.this.restoreKeyCallback(NokeMobileApiClient.POST(url, jsonObject.toString(), nokeMobileApiKey, proxyAddress, port), noke);
-                    } catch (PackageManager.NameNotFoundException | NullPointerException e) {
-                        e.printStackTrace();
-                        mGlobalNokeListener.onError(null, NokeMobileError.ERROR_MISSING_API_KEY, "No API Key found. Have you set it in your Android Manifest?");
-                        noke.isRestoring = false;
-                    }
+                    String nokeMobileApiKey = getMobileApiKey();
+                    NokeDeviceManagerService.this.restoreKeyCallback(NokeMobileApiClient.POST(url, jsonObject.toString(), nokeMobileApiKey, proxyAddress, port), noke);
                 } catch (Exception e) {
                     e.printStackTrace();
                     noke.isRestoring = false;
@@ -1531,16 +1557,8 @@ public class NokeDeviceManagerService extends Service {
                     jsonObject.accumulate("mac", mac);
                     jsonObject.accumulate("command_id", commandid);
                     String url = NokeDefines.uploadURL.replace("upload/", "restore/confirm/");
-                    try {
-                        PackageManager pm = getApplicationContext().getPackageManager();
-                        ApplicationInfo ai = pm.getApplicationInfo(getApplicationContext().getPackageName(), PackageManager.GET_META_DATA);
-                        Bundle bundle = ai.metaData;
-                        String nokeMobileApiKey = bundle.getString(NokeDefines.NOKE_MOBILE_API_KEY);
-                        NokeDeviceManagerService.this.confirmRestoreCallback(NokeMobileApiClient.POST(url, jsonObject.toString(), nokeMobileApiKey, proxyAddress, port));
-                    } catch (PackageManager.NameNotFoundException | NullPointerException e) {
-                        e.printStackTrace();
-                        mGlobalNokeListener.onError(null, NokeMobileError.ERROR_MISSING_API_KEY, "No API Key found. Have you set it in your Android Manifest?");
-                    }
+                    String nokeMobileApiKey = getMobileApiKey();
+                    NokeDeviceManagerService.this.confirmRestoreCallback(NokeMobileApiClient.POST(url, jsonObject.toString(), nokeMobileApiKey, proxyAddress, port));
                 } catch (Exception e) {
                     e.printStackTrace();
                 }


### PR DESCRIPTION
This adds an overloaded getService(int, String) method that takes the mode
and the mobile API key. This enables an alternative way of specifyin the
API key for applications where it's not known at compile time.

It's still possible to use the previous getService(int)
method and set the API key through the manifest meta-data. If the API key is
specified both in the manifest and dynamically, the dynamically set value is used.

To avoid duplicate code in three places to retrieve the API key in one of two ways,
a getMobileKey() helper method was also extracted.